### PR TITLE
Fix dyn-ui-react public exports

### DIFF
--- a/packages/dyn-ui-react/src/index.ts
+++ b/packages/dyn-ui-react/src/index.ts
@@ -1,65 +1,28 @@
-// Entry point for dyn-ui-react components
+// Public entry point for dyn-ui-react
+// Re-export the full component surface along with supporting utilities
 
-// Button Components
-export { default as DynButton } from './components/DynButton/DynButton';
+// Components and related types/constants
+export * from './components';
 
-// Display Components
-export { default as DynIcon } from './components/DynIcon/DynIcon';
-export { DynAvatar } from './components/DynAvatar/DynAvatar';
-export { DynBadge } from './components/DynBadge/DynBadge';
-export { DynImage } from './components/DynImage/DynImage';
-export { DynTag } from './components/DynTag/DynTag';
-export { DynGauge } from './components/DynGauge/DynGauge';
-export { DynChart } from './components/DynChart/DynChart';
-export { DynKanban } from './components/DynKanban/DynKanban';
+// Theme system
+export { ThemeProvider, useTheme } from './theme/ThemeProvider';
+export type { ThemeProviderProps, ThemeContextValue, Theme } from './theme/ThemeProvider';
 
-// Layout Components
-export { DynPage } from './components/DynPage/DynPage';
-export { DynGrid } from './components/DynGrid/DynGrid';
-export { DynCard } from './components/DynCard/DynCard';
-export { DynContainer } from './components/DynContainer/DynContainer';
-export { DynCollapse } from './components/DynCollapse/DynCollapse';
-export { DynDivider } from './components/DynDivider/DynDivider';
-export { DynDrawer } from './components/DynDrawer/DynDrawer';
-export { DynSplit } from './components/DynSplit/DynSplit';
-export { DynStackLayout } from './components/DynStackLayout/DynStackLayout';
+// Providers
+export { IconDictionaryProvider } from './providers';
 
-// Navigation Components
-export { default as DynTabs } from './components/DynTabs/DynTabs';
-export { default as DynStepper } from './components/DynStepper/DynStepper';
-export { DynBreadcrumb } from './components/DynBreadcrumb/DynBreadcrumb';
-export { DynMenu } from './components/DynMenu/DynMenu';
-export { DynPagination } from './components/DynPagination/DynPagination';
-export { DynPopover } from './components/DynPopover/DynPopover';
-export { DynTooltip } from './components/DynTooltip/DynTooltip';
+// Hooks
+export { useThemeVars } from './hooks/useTheme';
+export { useIconDictionary } from './hooks/useIconDictionary';
 
-// Form Components
-export { DynInput } from './components/DynInput/DynInput';
-export { DynSelect } from './components/DynSelect/DynSelect';
-export { DynCheckbox } from './components/DynCheckbox/DynCheckbox';
-export { DynRadio } from './components/DynRadio/DynRadio';
-export { DynSlider } from './components/DynSlider/DynSlider';
-export { DynSwitch } from './components/DynSwitch/DynSwitch';
-export { DynTextarea } from './components/DynTextarea/DynTextarea';
-export { DynDatepicker } from './components/DynDatepicker/DynDatepicker';
-export { DynUpload } from './components/DynUpload/DynUpload';
+// Root types
+export type { ThemeName, ThemeConfig, ColorVariant, Size, IconDictionary } from './types';
 
-// Feedback Components
-export { DynAlert } from './components/DynAlert/DynAlert';
-export { DynConfirmDialog } from './components/DynConfirmDialog/DynConfirmDialog';
-export { DynLoading } from './components/DynLoading/DynLoading';
-export { DynModal } from './components/DynModal/DynModal';
-export { DynToast } from './components/DynToast/DynToast';
-
-// Data Display Components
-export { DynTable } from './components/DynTable/DynTable';
-export { DynTree } from './components/DynTree/DynTree';
-export { DynTimeline } from './components/DynTimeline/DynTimeline';
-
-// Utility Components
-export { DynPortal } from './components/DynPortal/DynPortal';
-
-// Types
-export * from './types';
-
-// Add other components here as they are implemented
+// Utilities
+export { classNames, createClassNameGenerator, combineClasses } from './utils/classNames';
+export {
+  generateInitials,
+  formatBadgeValue,
+  isThemeColor,
+  processIconString,
+} from './utils/dynFormatters';


### PR DESCRIPTION
## Summary
- update the `@dyn-ui/react` TypeScript entry point to re-export the full component surface from the barrel modules
- expose theme, provider, hook, type, and utility exports to align with the TSX entry point and fix the DynDatePicker path

## Testing
- `npm run test` *(fails: existing test suite reports many component rendering failures unrelated to the new barrel exports)*
- `npm run build-storybook` *(fails: Storybook build cannot resolve the `@storybook/react-vite` dependency in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e54b3bee408324bcc0e8b2d3fd74b8