### PR TITLE
Ensure DynChart filtered tests run across packages

### DIFF
--- a/apps/react-demo/package.json
+++ b/apps/react-demo/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -6,6 +6,6 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "rollup -c rollup.config.mjs",
-    "test": "vitest run"
+    "test": "vitest run --passWithNoTests"
   }
 }

--- a/packages/dyn-ui-react/src/components/DynChart/DynChart.module.css
+++ b/packages/dyn-ui-react/src/components/DynChart/DynChart.module.css
@@ -1,23 +1,28 @@
-﻿/* DynChart Component Styles */
-.dyn-chart {
+.root {
   display: flex;
   flex-direction: column;
-  gap: 16px;
   background: var(--dyn-color-background);
   border-radius: var(--dyn-border-radius-md);
   border: 1px solid var(--dyn-color-border);
   padding: 16px;
   font-family: var(--dyn-font-family-base);
+  gap: 16px;
 }
 
-/* Header */
-.dyn-chart__header {
+.figure {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin: 0;
+}
+
+.header {
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
 
-.dyn-chart__title {
+.title {
   margin: 0;
   font-size: var(--dyn-font-size-lg);
   font-weight: var(--dyn-font-weight-semibold);
@@ -25,7 +30,7 @@
   line-height: var(--dyn-line-height-tight);
 }
 
-.dyn-chart__subtitle {
+.subtitle {
   margin: 0;
   font-size: var(--dyn-font-size-sm);
   font-weight: var(--dyn-font-weight-normal);
@@ -33,21 +38,20 @@
   line-height: var(--dyn-line-height-normal);
 }
 
-/* Chart Content */
-.dyn-chart__content {
+.content {
   position: relative;
   display: flex;
   justify-content: center;
   align-items: center;
 }
 
-.dyn-chart__canvas {
+.canvas {
   display: block;
   max-width: 100%;
   height: auto;
 }
 
-.dyn-chart__tooltip {
+.tooltip {
   position: absolute;
   max-width: 220px;
   padding: 8px 12px;
@@ -67,48 +71,47 @@
   word-break: break-word;
 }
 
-.dyn-chart__tooltip[data-visible='true'] {
+.tooltip[data-visible='true'] {
   opacity: 1;
   visibility: visible;
 }
 
-.dyn-chart__tooltip-header {
+.tooltipHeader {
   display: flex;
   align-items: center;
   gap: 8px;
   margin-bottom: 4px;
 }
 
-.dyn-chart__tooltip-color {
+.tooltipColor {
   width: 10px;
   height: 10px;
   border-radius: 50%;
   flex-shrink: 0;
 }
 
-.dyn-chart__tooltip-series {
+.tooltipSeries {
   font-weight: var(--dyn-font-weight-semibold);
 }
 
-.dyn-chart__tooltip-percentage {
+.tooltipPercentage {
   margin-left: auto;
   font-size: var(--dyn-font-size-xs);
   opacity: 0.85;
 }
 
-.dyn-chart__tooltip-value {
+.tooltipValue {
   font-weight: var(--dyn-font-weight-semibold);
   font-size: var(--dyn-font-size-sm);
   margin-bottom: 2px;
 }
 
-.dyn-chart__tooltip-label {
+.tooltipLabel {
   font-size: var(--dyn-font-size-xs);
   opacity: 0.85;
 }
 
-/* Legend */
-.dyn-chart__legend {
+.legend {
   display: flex;
   flex-wrap: wrap;
   gap: 16px;
@@ -117,7 +120,7 @@
   padding: 8px 0;
 }
 
-.dyn-chart__legend-item {
+.legendItem {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -125,88 +128,88 @@
   color: var(--dyn-color-text-secondary);
 }
 
-.dyn-chart__legend-color {
+.legendColor {
   width: 12px;
   height: 12px;
   border-radius: 2px;
   flex-shrink: 0;
 }
 
-.dyn-chart__legend-label {
+.legendLabel {
   font-weight: var(--dyn-font-weight-normal);
   line-height: var(--dyn-line-height-normal);
 }
 
-/* Chart Type Variants */
-.dyn-chart--line {
-  /* Line chart specific styles */
+.typeLine {}
+
+.typeBar {}
+
+.typePie {}
+
+.typeArea {}
+
+.emptyState {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--dyn-font-size-sm);
+  color: var(--dyn-color-text-secondary);
+  pointer-events: none;
 }
 
-.dyn-chart--bar {
-  /* Bar chart specific styles */
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
-.dyn-chart--pie {
-  /* Pie chart specific styles */
-}
-
-.dyn-chart--area {
-  /* Area chart specific styles */
-}
-
-/* Responsive Design */
 @media (max-width: 768px) {
-  .dyn-chart {
+  .root {
     padding: 12px;
   }
 
-  .dyn-chart__title {
+  .title {
     font-size: var(--dyn-font-size-base);
   }
 
-  .dyn-chart__subtitle {
+  .subtitle {
     font-size: var(--dyn-font-size-xs);
   }
 
-  .dyn-chart__legend {
+  .legend {
     gap: 12px;
   }
 
-  .dyn-chart__legend-item {
+  .legendItem {
     gap: 6px;
     font-size: var(--dyn-font-size-xs);
   }
 }
 
-/* Dark Theme Support */
-[data-theme="dark"] .dyn-chart {
+[data-theme='dark'] .root {
   background: var(--dyn-color-background-dark);
   border-color: var(--dyn-color-border-dark);
 }
 
-[data-theme="dark"] .dyn-chart__title {
+[data-theme='dark'] .title {
   color: var(--dyn-color-text-primary-dark);
 }
 
-[data-theme="dark"] .dyn-chart__subtitle,
-[data-theme="dark"] .dyn-chart__legend-item {
+[data-theme='dark'] .subtitle,
+[data-theme='dark'] .legendItem {
   color: var(--dyn-color-text-secondary-dark);
 }
 
-/* High Contrast Mode */
 @media (prefers-contrast: high) {
-  .dyn-chart {
+  .root {
     border-width: 2px;
-  }
-
-  .dyn-chart__legend-color {
-    border: 1px solid var(--dyn-color-border);
-  }
-}
-
-/* Reduced Motion */
-@media (prefers-reduced-motion: reduce) {
-  .dyn-chart__canvas {
-    /* Disable any potential animations */
   }
 }

--- a/packages/dyn-ui-react/src/components/DynChart/DynChart.stories.tsx
+++ b/packages/dyn-ui-react/src/components/DynChart/DynChart.stories.tsx
@@ -1,60 +1,7 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
-import DynChart from './DynChart';
-import { DynChartProps, ChartDataPoint, ChartSeries } from './DynChart.types';
+import type { Meta, StoryObj } from '@storybook/react';
+import { DynChart } from './DynChart';
+import type { ChartDataPoint, ChartSeries, DynChartProps } from './DynChart.types';
 
-const meta: Meta<typeof DynChart> = {
-  title: 'Data Display/DynChart',
-  component: DynChart,
-  parameters: {
-    layout: 'centered',
-    docs: {
-      description: {
-        component: 'A versatile chart component that supports line, bar, pie, and area charts with customizable styling and interactive features.'
-      }
-    }
-  },
-  tags: ['autodocs'],
-  argTypes: {
-    type: {
-      control: { type: 'select' },
-      options: ['line', 'bar', 'pie', 'area'],
-      description: 'Chart type to display'
-    },
-    title: {
-      control: 'text',
-      description: 'Chart title'
-    },
-    subtitle: {
-      control: 'text',
-      description: 'Chart subtitle'
-    },
-    width: {
-      control: { type: 'number', min: 200, max: 1000 },
-      description: 'Chart width in pixels'
-    },
-    height: {
-      control: { type: 'number', min: 150, max: 600 },
-      description: 'Chart height in pixels'
-    },
-    showLegend: {
-      control: 'boolean',
-      description: 'Show chart legend'
-    },
-    showGrid: {
-      control: 'boolean',
-      description: 'Show grid lines'
-    },
-    showTooltip: {
-      control: 'boolean',
-      description: 'Show tooltip on hover'
-    },
-  },
-};
-
-export default meta;
-type Story = StoryObj<typeof DynChart>;
-
-// Sample data
 const sampleDataPoints: ChartDataPoint[] = [
   { label: 'Jan', value: 65 },
   { label: 'Feb', value: 78 },
@@ -68,18 +15,18 @@ const multiSeriesData: ChartSeries[] = [
   {
     name: 'Revenue',
     data: sampleDataPoints,
-    color: '#0066cc'
+    color: '#0066cc',
   },
   {
     name: 'Costs',
-    data: sampleDataPoints.map(d => ({ ...d, value: d.value * 0.7 })),
-    color: '#f44336'
+    data: sampleDataPoints.map(point => ({ ...point, value: point.value * 0.7 })),
+    color: '#f44336',
   },
   {
     name: 'Profit',
-    data: sampleDataPoints.map(d => ({ ...d, value: d.value * 0.3 })),
-    color: '#00b248'
-  }
+    data: sampleDataPoints.map(point => ({ ...point, value: point.value * 0.3 })),
+    color: '#00b248',
+  },
 ];
 
 const pieData: ChartDataPoint[] = [
@@ -89,159 +36,150 @@ const pieData: ChartDataPoint[] = [
   { label: 'Other', value: 5, color: '#ff9800' },
 ];
 
-// Default story
-export const Default: Story = {
+const meta = {
+  title: 'Data Display/DynChart',
+  component: DynChart,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'A versatile chart component that supports line, bar, pie and area visualisations with dynamic styling, built-in legend and tooltip support.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    type: {
+      control: { type: 'select' },
+      options: ['line', 'bar', 'pie', 'area'],
+      description: 'Select the chart visualisation variant.',
+    },
+    title: {
+      control: 'text',
+      description: 'Chart title used for visual and accessible labelling.',
+    },
+    subtitle: {
+      control: 'text',
+      description: 'Optional subtitle displayed below the title.',
+    },
+    ariaDescription: {
+      control: 'text',
+      description: 'Descriptive text exposed to assistive technologies via figcaption.',
+    },
+    width: {
+      control: { type: 'number', min: 200, max: 1000 },
+      description: 'Canvas width in pixels.',
+    },
+    height: {
+      control: { type: 'number', min: 150, max: 600 },
+      description: 'Canvas height in pixels.',
+    },
+    showLegend: {
+      control: 'boolean',
+      description: 'Toggle the legend visibility.',
+    },
+    showTooltip: {
+      control: 'boolean',
+      description: 'Toggle tooltip interactions.',
+    },
+    showGrid: {
+      control: 'boolean',
+      description: 'Toggle axis grid rendering (non-pie charts).',
+    },
+  },
   args: {
     data: sampleDataPoints,
     type: 'line',
     title: 'Monthly Sales',
-    subtitle: 'Sales performance over 6 months',
+    subtitle: 'Sales performance over six months',
     width: 500,
     height: 300,
     showLegend: true,
-    showGrid: true,
     showTooltip: true,
-  },
-};
+    showGrid: true,
+  } satisfies DynChartProps,
+} satisfies Meta<typeof DynChart>;
 
-// Line Chart
-export const LineChart: Story = {
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Line: Story = {
   args: {
-    ...Default.args,
     type: 'line',
-    title: 'Line Chart Example',
+    title: 'Trend Line',
     data: sampleDataPoints,
   },
 };
 
-// Bar Chart
-export const BarChart: Story = {
+export const Bar: Story = {
   args: {
-    ...Default.args,
     type: 'bar',
-    title: 'Bar Chart Example',
+    title: 'Bar Comparison',
     data: sampleDataPoints,
   },
 };
 
-// Pie Chart
-export const PieChart: Story = {
+export const Pie: Story = {
   args: {
-    ...Default.args,
     type: 'pie',
     title: 'Device Usage Distribution',
     subtitle: 'Percentage of users by device type',
     data: pieData,
     width: 400,
     height: 400,
-  },
-};
-
-// Area Chart
-export const AreaChart: Story = {
-  args: {
-    ...Default.args,
-    type: 'area',
-    title: 'Area Chart Example',
-    data: sampleDataPoints,
-  },
-};
-
-// Multi-Series Chart
-export const MultiSeries: Story = {
-  args: {
-    ...Default.args,
-    type: 'line',
-    title: 'Financial Performance',
-    subtitle: 'Revenue, costs, and profit over time',
-    data: multiSeriesData,
-    width: 600,
-    height: 350,
-  },
-};
-
-// With Custom Colors
-export const CustomColors: Story = {
-  args: {
-    ...Default.args,
-    title: 'Custom Color Palette',
-    data: sampleDataPoints,
-    colors: ['#ff6b6b', '#4ecdc4', '#45b7d1', '#96ceb4', '#ffeaa7'],
-  },
-};
-
-// Without Legend
-export const NoLegend: Story = {
-  args: {
-    ...Default.args,
-    title: 'Chart Without Legend',
-    showLegend: false,
-  },
-};
-
-// Without Grid
-export const NoGrid: Story = {
-  args: {
-    ...Default.args,
-    title: 'Chart Without Grid',
     showGrid: false,
   },
 };
 
-// Small Chart
-export const SmallChart: Story = {
+export const Area: Story = {
   args: {
-    ...Default.args,
-    title: 'Small Chart',
-    width: 300,
-    height: 200,
+    type: 'area',
+    title: 'Area Highlight',
+    data: sampleDataPoints,
   },
 };
 
-// Large Chart
-export const LargeChart: Story = {
+export const MultiSeries: Story = {
   args: {
-    ...Default.args,
-    title: 'Large Chart',
-    width: 800,
-    height: 500,
+    type: 'line',
+    title: 'Financial Performance',
+    subtitle: 'Revenue, costs and profit over time',
+    data: multiSeriesData,
+    width: 640,
+    height: 360,
   },
 };
 
-// With Axis Labels
-export const WithAxisLabels: Story = {
+export const NoLegend: Story = {
   args: {
-    ...Default.args,
-    title: 'Chart with Axis Labels',
-    xAxis: {
-      title: 'Time Period',
-      showLabels: true,
-    },
-    yAxis: {
-      title: 'Sales ($K)',
-      showLabels: true,
-      min: 0,
-      max: 100,
-    },
+    showLegend: false,
   },
 };
 
-// Empty Data
-export const EmptyData: Story = {
+export const NoTooltip: Story = {
   args: {
-    ...Default.args,
-    title: 'Empty Chart',
-    subtitle: 'No data available',
+    showTooltip: false,
+  },
+};
+
+export const CustomColors: Story = {
+  args: {
+    colors: ['#ff6b6b', '#4ecdc4', '#45b7d1', '#96ceb4', '#ffeaa7'],
+  },
+};
+
+export const EmptyState: Story = {
+  args: {
     data: [],
+    title: 'No Data Example',
   },
 };
 
-// Loading State (simulated)
-export const LoadingState: Story = {
+export const WithDescription: Story = {
   args: {
-    ...Default.args,
-    title: 'Loading Chart...',
-    data: [],
-    className: 'loading-state',
+    ariaDescription: 'This chart compares revenue, costs and profit for the last six months.',
   },
 };

--- a/packages/dyn-ui-react/src/components/DynChart/DynChart.test.tsx
+++ b/packages/dyn-ui-react/src/components/DynChart/DynChart.test.tsx
@@ -1,12 +1,12 @@
-﻿// Removed unused import of React since it's not directly used in this file
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Mock } from 'vitest';
 import DynChart from './DynChart';
 import styles from './DynChart.module.css';
-import { ChartDataPoint } from './DynChart.types';
+import type { ChartDataPoint, ChartSeries } from './DynChart.types';
 
-// Mock HTMLCanvasElement
 const mockGetContext = vi.fn();
+
 Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
   value: mockGetContext,
 });
@@ -38,9 +38,10 @@ const mockCanvasContext: Record<string, any> = {
 
 beforeEach(() => {
   mockGetContext.mockReturnValue(mockCanvasContext);
+
   Object.keys(mockCanvasContext).forEach(key => {
     if (typeof mockCanvasContext[key as keyof typeof mockCanvasContext] === 'function') {
-      (mockCanvasContext[key as keyof typeof mockCanvasContext] as any).mockClear();
+      (mockCanvasContext[key as keyof typeof mockCanvasContext] as unknown as Mock).mockClear();
     }
   });
 });
@@ -52,157 +53,106 @@ const sampleData: ChartDataPoint[] = [
   { label: 'Apr', value: 25 },
 ];
 
+const multiSeriesData: ChartSeries[] = [
+  { name: 'Series 1', data: sampleData },
+  { name: 'Series 2', data: sampleData.map(point => ({ ...point, value: point.value * 2 })) },
+];
+
 describe('DynChart', () => {
-  describe('Rendering', () => {
-    it('renders without crashing', () => {
-      render(<DynChart data={sampleData} />);
-      expect(screen.getByRole('presentation', { hidden: true })).toBeInTheDocument();
-    });
+  it('renders canvas element with accessible role', () => {
+    render(<DynChart data={sampleData} title="Sales" />);
 
-    it('renders with title and subtitle', () => {
-      render(
-        <DynChart
-          data={sampleData}
-          title="Sales Chart"
-          subtitle="Monthly sales data"
-        />
-      );
+    const canvas = screen.getByRole('img', { name: 'Sales' });
+    expect(canvas).toBeInTheDocument();
+    expect(canvas).toHaveAttribute('aria-label', 'Sales');
+  });
 
-      expect(screen.getByText('Sales Chart')).toBeInTheDocument();
-      expect(screen.getByText('Monthly sales data')).toBeInTheDocument();
-    });
+  it('merges base and custom class names', () => {
+    const { container } = render(
+      <DynChart data={sampleData} className="custom-chart" />
+    );
 
-    it('renders legend when showLegend is true', () => {
-      render(
-        <DynChart
-          data={[{ name: 'Series 1', data: sampleData }]}
-          showLegend={true}
-        />
-      );
+    expect(container.firstChild).toHaveClass(styles.root);
+    expect(container.firstChild).toHaveClass('custom-chart');
+  });
 
-      expect(screen.getByText('Series 1')).toBeInTheDocument();
-    });
-
-    it('does not render legend when showLegend is false', () => {
-      render(
-        <DynChart
-          data={[{ name: 'Series 1', data: sampleData }]}
-          showLegend={false}
-        />
-      );
-
-      expect(screen.queryByText('Series 1')).not.toBeInTheDocument();
+  it('applies variant class names for each chart type', () => {
+    (['line', 'bar', 'pie', 'area'] as const).forEach(type => {
+      const { container, unmount } = render(<DynChart data={sampleData} type={type} />);
+      expect(container.firstChild).toHaveClass(styles.root);
+      const expectedClass =
+        type === 'line'
+          ? styles.typeLine
+          : type === 'bar'
+          ? styles.typeBar
+          : type === 'pie'
+          ? styles.typePie
+          : styles.typeArea;
+      expect(container.firstChild).toHaveClass(expectedClass ?? '');
+      unmount();
     });
   });
 
-  describe('Props', () => {
-    it('applies custom className', () => {
-      const { container } = render(
-        <DynChart data={sampleData} className="custom-chart" />
-      );
+  it('renders legend items when enabled', () => {
+    render(<DynChart data={multiSeriesData} showLegend />);
 
-      expect(container.firstChild).toHaveClass('custom-chart');
-    });
-
-    it('sets canvas dimensions', () => {
-      render(
-        <DynChart
-          data={sampleData}
-          width={500}
-          height={400}
-        />
-      );
-
-      const canvas = screen.getByRole('presentation', { hidden: true }) as HTMLCanvasElement;
-      expect(canvas).toHaveStyle({ width: '500px', height: '400px' });
-    });
-
-    it('handles empty data', () => {
-      render(<DynChart data={[]} />);
-      expect(screen.getByRole('presentation', { hidden: true })).toBeInTheDocument();
-    });
+    expect(screen.getByRole('list')).toBeInTheDocument();
+    expect(screen.getByText('Series 1')).toBeInTheDocument();
+    expect(screen.getByText('Series 2')).toBeInTheDocument();
   });
 
-  describe('Chart Types', () => {
-    it('renders line chart by default', () => {
-      const { container } = render(<DynChart data={sampleData} />);
-      expect(container.firstChild).toHaveClass(styles['dyn-chart--line']!);
-    });
+  it('omits legend when disabled', () => {
+    render(<DynChart data={multiSeriesData} showLegend={false} />);
 
-    it('renders bar chart when type is bar', () => {
-      const { container } = render(<DynChart data={sampleData} type="bar" />);
-      expect(container.firstChild).toHaveClass(styles['dyn-chart--bar'] ?? '');
-    });
-
-    it('renders pie chart when type is pie', () => {
-      const { container } = render(<DynChart data={sampleData} type="pie" />);
-      expect(container.firstChild).toHaveClass(styles['dyn-chart--pie'] ?? '');
-    });
-
-    it('renders area chart when type is area', () => {
-      const { container } = render(<DynChart data={sampleData} type="area" />);
-      expect(container.firstChild).toHaveClass(styles['dyn-chart--area'] ?? '');
-    });
+    expect(screen.queryByRole('list')).not.toBeInTheDocument();
   });
 
-  describe('Canvas Drawing', () => {
-    it('calls getContext on canvas', () => {
-      render(<DynChart data={sampleData} />);
-      expect(mockGetContext).toHaveBeenCalledWith('2d');
-    });
+  it('renders tooltip container only when enabled', () => {
+    const { rerender, container } = render(<DynChart data={sampleData} showTooltip />);
+    expect(container.querySelector(`.${styles.tooltip}`)).toBeInTheDocument();
 
-    it('clears canvas on render', () => {
-      render(<DynChart data={sampleData} />);
-      expect(mockCanvasContext.clearRect).toHaveBeenCalled();
-    });
-
-    it('draws grid when showGrid is true', () => {
-      render(<DynChart data={sampleData} showGrid={true} />);
-      expect(mockCanvasContext.setLineDash).toHaveBeenCalledWith([2, 2]);
-    });
+    rerender(<DynChart data={sampleData} showTooltip={false} />);
+    expect(container.querySelector(`.${styles.tooltip}`)).not.toBeInTheDocument();
   });
 
-  describe('Data Handling', () => {
-    it('handles single data points array', () => {
-      render(<DynChart data={sampleData} />);
-      expect(mockGetContext).toHaveBeenCalled();
-    });
+  it('initializes tooltip visibility as hidden', () => {
+    const { container } = render(<DynChart data={sampleData} showTooltip />);
 
-    it('handles series data format', () => {
-      const seriesData = [
-        { name: 'Series 1', data: sampleData },
-        { name: 'Series 2', data: sampleData.map(d => ({ ...d, value: d.value * 2 })) },
-      ];
-
-      render(<DynChart data={seriesData} />);
-      expect(screen.getByText('Series 1')).toBeInTheDocument();
-      expect(screen.getByText('Series 2')).toBeInTheDocument();
-    });
+    const tooltip = container.querySelector(`.${styles.tooltip}`);
+    expect(tooltip).toHaveAttribute('data-visible', 'false');
   });
 
-  describe('Tooltip', () => {
-    it('renders tooltip container when enabled', () => {
-      const { container } = render(<DynChart data={sampleData} showTooltip />);
-      expect(container.querySelector(`.${styles['dyn-chart__tooltip']}`)).toBeInTheDocument();
-    });
+  it('shows empty state message for empty data', () => {
+    render(<DynChart data={[]} />);
 
-    it('does not render tooltip container when disabled', () => {
-      const { container } = render(<DynChart data={sampleData} showTooltip={false} />);
-      expect(container.querySelector(`.${styles['dyn-chart__tooltip']}`)).toBeNull();
-    });
+    expect(screen.getByRole('status')).toHaveTextContent('No chart data available');
   });
 
-  describe('Accessibility', () => {
-    it('has appropriate ARIA attributes', () => {
-      render(
-        <DynChart
-          data={sampleData}
-          title="Sales Chart"
-        />
-      );
+  it('shows empty state message for zero-value series', () => {
+    const zeroSeries: ChartDataPoint[] = [
+      { label: 'A', value: 0 },
+      { label: 'B', value: 0 },
+    ];
 
-      const canvas = screen.getByRole('presentation', { hidden: true });
-      expect(canvas).toBeInTheDocument();
-    });
+    render(<DynChart data={zeroSeries} />);
+
+    expect(screen.getByRole('status')).toHaveTextContent('Chart data contains no measurable values');
   });
+
+  it('provides descriptive figcaption when ariaDescription is passed', () => {
+    render(
+      <DynChart data={sampleData} title="Chart" ariaDescription="Quarterly sales overview" />
+    );
+
+    const figcaption = screen.getByText('Quarterly sales overview');
+    expect(figcaption.tagName).toBe('FIGCAPTION');
+  });
+
+  it('calls canvas drawing functions during render', () => {
+    render(<DynChart data={sampleData} />);
+
+    expect(mockGetContext).toHaveBeenCalledWith('2d');
+    expect(mockCanvasContext.clearRect).toHaveBeenCalled();
+  });
+
 });

--- a/packages/dyn-ui-react/src/components/DynChart/DynChart.tsx
+++ b/packages/dyn-ui-react/src/components/DynChart/DynChart.tsx
@@ -1,6 +1,22 @@
-﻿import React, { useMemo, useRef, useEffect, useState, useCallback } from 'react';
-import classNames from 'classnames';
-import { DynChartProps, ChartSeries, ChartDataPoint } from './DynChart.types';
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import type { MouseEvent } from 'react';
+import { cn } from '../../utils/classNames';
+import { DYN_CHART_DEFAULT_PROPS, DynChartProps } from './DynChart.types';
+import {
+  buildLegendItems,
+  calculateChartDimensions,
+  calculateDataRanges,
+  getEmptyStateMessage,
+  normalizeSeries,
+} from './DynChart.utils';
 import styles from './DynChart.module.css';
 
 type TooltipTarget =
@@ -44,10 +60,10 @@ interface TooltipState {
   x: number;
   y: number;
   value: number;
-  label: string | undefined;
-  series: string | undefined;
-  color: string | undefined;
-  percentage: number | undefined;
+  label?: string;
+  series?: string;
+  color?: string;
+  percentage?: number;
 }
 
 const normalizeAngle = (angle: number) => {
@@ -56,105 +72,73 @@ const normalizeAngle = (angle: number) => {
   return normalized >= 0 ? normalized : normalized + twoPi;
 };
 
-// Simple chart implementation without external dependencies
-const DynChart: React.FC<DynChartProps> = ({
-  type = 'line',
-  data = [],
-  title,
-  subtitle,
-  width = 400,
-  height = 300,
-  colors = ['#0066cc', '#00b248', '#f44336', '#ff9800', '#9c27b0'],
-  showLegend = true,
-  showTooltip = true,
-  showGrid = true,
-  xAxis,
-  yAxis,
-  className,
-}) => {
+const typeClassNameMap: Record<'line' | 'bar' | 'pie' | 'area', string | undefined> = {
+  line: styles.typeLine,
+  bar: styles.typeBar,
+  pie: styles.typePie,
+  area: styles.typeArea,
+};
+
+const DynChart = forwardRef<HTMLDivElement, DynChartProps>((props, ref) => {
+  const {
+    type = DYN_CHART_DEFAULT_PROPS.type,
+    data = DYN_CHART_DEFAULT_PROPS.data,
+    title,
+    subtitle,
+    width = DYN_CHART_DEFAULT_PROPS.width,
+    height = DYN_CHART_DEFAULT_PROPS.height,
+    colors = DYN_CHART_DEFAULT_PROPS.colors,
+    showLegend = DYN_CHART_DEFAULT_PROPS.showLegend,
+    showTooltip = DYN_CHART_DEFAULT_PROPS.showTooltip,
+    showGrid = DYN_CHART_DEFAULT_PROPS.showGrid,
+    xAxis,
+    yAxis,
+    ariaDescription,
+    className,
+    id,
+    children,
+    'data-testid': dataTestId,
+    ...rest
+  } = props;
+
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
   const tooltipTargetsRef = useRef<TooltipTarget[]>([]);
   const [tooltipState, setTooltipState] = useState<TooltipState>({
     visible: false,
     x: 0,
     y: 0,
     value: 0,
-    label: undefined,
-    series: undefined,
-    color: undefined,
-    percentage: undefined,
   });
 
-  // Normalize data to series format
-  const normalizedData: ChartSeries[] = useMemo(() => {
-    if (!data.length) return [];
+  const instanceId = useId();
+  const titleId = title ? `${id ?? instanceId}-title` : undefined;
+  const subtitleId = subtitle ? `${id ?? instanceId}-subtitle` : undefined;
+  const descriptionId = ariaDescription ? `${id ?? instanceId}-description` : undefined;
 
-    // If data is already in series format
-    if (Array.isArray(data) && data[0] && 'name' in data[0]) {
-      return data as ChartSeries[];
-    }
+  const normalizedData = useMemo(
+    () => normalizeSeries(data, colors),
+    [data, colors]
+  );
 
-    // Convert data points to single series
-    return [
-      {
-        name: 'Series 1',
-        data: data as ChartDataPoint[],
-        color: colors[0] || '#0066cc',
-      },
-    ];
-  }, [data, colors]);
+  const chartDimensions = useMemo(
+    () => calculateChartDimensions(width, height),
+    [width, height]
+  );
 
-  // Calculate chart dimensions
-  const chartDimensions = useMemo(() => {
-    const padding = { top: 20, right: 20, bottom: 60, left: 60 };
-    const chartWidth = width - padding.left - padding.right;
-    const chartHeight = height - padding.top - padding.bottom;
+  const dataRanges = useMemo(
+    () => calculateDataRanges(normalizedData, yAxis),
+    [normalizedData, yAxis]
+  );
 
-    return {
-      padding,
-      chartWidth,
-      chartHeight,
-      totalWidth: width,
-      totalHeight: height,
-    };
-  }, [width, height]);
+  const legendItems = useMemo(
+    () => buildLegendItems(normalizedData),
+    [normalizedData]
+  );
 
-  // Calculate data ranges
-  const dataRanges = useMemo(() => {
-    if (!normalizedData.length) return { minX: 0, maxX: 0, minY: 0, maxY: 0 };
-
-    let minY = yAxis?.min ?? Infinity;
-    let maxY = yAxis?.max ?? -Infinity;
-    let minX = 0;
-    let maxX = 0;
-
-    normalizedData.forEach(series => {
-      series.data.forEach((point, index) => {
-        if (yAxis?.min === undefined) {
-          minY = Math.min(minY, point.value);
-        }
-        if (yAxis?.max === undefined) {
-          maxY = Math.max(maxY, point.value);
-        }
-        maxX = Math.max(maxX, index);
-      });
-    });
-
-    // Add some padding to Y axis
-    if (yAxis?.min === undefined) {
-      minY = Math.max(0, minY * 0.9);
-    }
-    if (yAxis?.max === undefined) {
-      maxY = maxY * 1.1;
-    }
-
-    if (!Number.isFinite(minY) || !Number.isFinite(maxY)) {
-      return { minX, maxX, minY: 0, maxY: 1 };
-    }
-
-    return { minX, maxX, minY, maxY };
-  }, [normalizedData, yAxis]);
+  const emptyStateMessage = useMemo(
+    () => getEmptyStateMessage(normalizedData),
+    [normalizedData]
+  );
 
   const hideTooltip = useCallback(() => {
     setTooltipState(prev => (prev.visible ? { ...prev, visible: false } : prev));
@@ -199,11 +183,11 @@ const DynChart: React.FC<DynChartProps> = ({
       }
     }
 
-    return null;
+    return undefined;
   }, []);
 
   const handleMouseMove = useCallback(
-    (event: React.MouseEvent<HTMLCanvasElement>) => {
+    (event: MouseEvent<HTMLCanvasElement>) => {
       if (!showTooltip) {
         return;
       }
@@ -222,11 +206,14 @@ const DynChart: React.FC<DynChartProps> = ({
           x: offsetX + 12,
           y: offsetY - 12,
           value: target.value,
-          label: target.label,
           series: target.series,
           color: target.color,
           percentage: target.kind === 'slice' ? target.percentage : undefined,
         };
+
+        if (typeof target.label === 'string' && target.label.length > 0) {
+          nextState.label = target.label;
+        }
 
         if (
           prev.visible &&
@@ -261,405 +248,449 @@ const DynChart: React.FC<DynChartProps> = ({
     }
   }, [hideTooltip, showTooltip]);
 
-  // Drawing functions
-  const drawGrid = (ctx: CanvasRenderingContext2D) => {
-    if (!showGrid) return;
+  useEffect(() => () => hideTooltip(), [hideTooltip]);
 
-    const { padding, chartWidth, chartHeight } = chartDimensions;
+  const drawGrid = useCallback(
+    (ctx: CanvasRenderingContext2D) => {
+      if (!showGrid || type === 'pie') return;
 
-    ctx.strokeStyle = '#e0e0e0';
-    ctx.lineWidth = 1;
-    ctx.setLineDash([2, 2]);
+      const { padding, chartWidth, chartHeight } = chartDimensions;
 
-    // Horizontal grid lines
-    for (let i = 0; i <= 5; i++) {
-      const y = padding.top + (chartHeight / 5) * i;
-      ctx.beginPath();
-      ctx.moveTo(padding.left, y);
-      ctx.lineTo(padding.left + chartWidth, y);
-      ctx.stroke();
-    }
+      ctx.save();
+      ctx.strokeStyle = '#e0e0e0';
+      ctx.lineWidth = 1;
+      ctx.setLineDash([2, 2]);
 
-    const maxDataPoints = normalizedData.length
-      ? Math.max(...normalizedData.map(s => s.data.length))
-      : 0;
-
-    if (maxDataPoints > 1) {
-      const stepCount = Math.min(maxDataPoints - 1, 10);
-      for (let i = 0; i <= stepCount; i++) {
-        const x = padding.left + (chartWidth / stepCount) * i;
+      for (let i = 0; i <= 5; i++) {
+        const y = padding.top + (chartHeight / 5) * i;
         ctx.beginPath();
-        ctx.moveTo(x, padding.top);
-        ctx.lineTo(x, padding.top + chartHeight);
+        ctx.moveTo(padding.left, y);
+        ctx.lineTo(padding.left + chartWidth, y);
         ctx.stroke();
       }
-    }
 
-    ctx.setLineDash([]);
-  };
+      const maxDataPoints = normalizedData.length
+        ? Math.max(...normalizedData.map(series => series.data.length))
+        : 0;
 
-  const drawAxes = (ctx: CanvasRenderingContext2D) => {
-    const { padding, chartWidth, chartHeight } = chartDimensions;
+      if (maxDataPoints > 1) {
+        const stepCount = Math.min(maxDataPoints - 1, 10);
+        for (let i = 0; i <= stepCount; i++) {
+          const x = padding.left + (chartWidth / stepCount) * i;
+          ctx.beginPath();
+          ctx.moveTo(x, padding.top);
+          ctx.lineTo(x, padding.top + chartHeight);
+          ctx.stroke();
+        }
+      }
 
-    ctx.strokeStyle = '#333';
-    ctx.lineWidth = 2;
-
-    // X axis
-    ctx.beginPath();
-    ctx.moveTo(padding.left, padding.top + chartHeight);
-    ctx.lineTo(padding.left + chartWidth, padding.top + chartHeight);
-    ctx.stroke();
-
-    // Y axis
-    ctx.beginPath();
-    ctx.moveTo(padding.left, padding.top);
-    ctx.lineTo(padding.left, padding.top + chartHeight);
-    ctx.stroke();
-
-    // Axis labels
-    ctx.fillStyle = '#666';
-    ctx.font = '12px Arial';
-    ctx.textAlign = 'center';
-
-    // X axis title
-    if (xAxis?.title) {
-      ctx.fillText(xAxis.title, padding.left + chartWidth / 2, height - 10);
-    }
-
-    // Y axis title
-    if (yAxis?.title) {
-      ctx.save();
-      ctx.translate(15, padding.top + chartHeight / 2);
-      ctx.rotate(-Math.PI / 2);
-      ctx.fillText(yAxis.title, 0, 0);
       ctx.restore();
-    }
+    },
+    [chartDimensions, normalizedData, showGrid, type]
+  );
 
-    // Y axis values
-    ctx.textAlign = 'right';
-    for (let i = 0; i <= 5; i++) {
-      const value =
-        dataRanges.minY + ((dataRanges.maxY - dataRanges.minY) / 5) * (5 - i);
-      const y = padding.top + (chartHeight / 5) * i;
-      ctx.fillText(value.toFixed(1), padding.left - 10, y + 5);
-    }
-  };
+  const drawAxes = useCallback(
+    (ctx: CanvasRenderingContext2D) => {
+      if (type === 'pie') return;
 
-  const drawLineChart = (ctx: CanvasRenderingContext2D) => {
-    const { padding, chartWidth, chartHeight } = chartDimensions;
-    const yRange = Math.max(dataRanges.maxY - dataRanges.minY || 0, 1);
+      const { padding, chartWidth, chartHeight } = chartDimensions;
 
-    normalizedData.forEach((series, seriesIndex) => {
-      const color = series.color || colors[seriesIndex % colors.length] || '#0066cc';
-
-      ctx.strokeStyle = color || '#000';
-      ctx.fillStyle = color || '#000';
-      ctx.lineWidth = 3;
-      ctx.lineCap = 'round';
-      ctx.lineJoin = 'round';
-
-      if (series.data.length === 0) return;
+      ctx.save();
+      ctx.strokeStyle = '#333';
+      ctx.lineWidth = 2;
 
       ctx.beginPath();
-
-      series.data.forEach((point, index) => {
-        const x =
-          padding.left + (chartWidth / Math.max(series.data.length - 1, 1)) * index;
-        const y =
-          padding.top +
-          chartHeight -
-          ((point.value - dataRanges.minY) / yRange) * chartHeight;
-
-        if (index === 0) {
-          ctx.moveTo(x, y);
-        } else {
-          ctx.lineTo(x, y);
-        }
-      });
-
+      ctx.moveTo(padding.left, padding.top + chartHeight);
+      ctx.lineTo(padding.left + chartWidth, padding.top + chartHeight);
       ctx.stroke();
 
-      series.data.forEach((point, index) => {
-        const x =
-          padding.left + (chartWidth / Math.max(series.data.length - 1, 1)) * index;
-        const y =
-          padding.top +
-          chartHeight -
-          ((point.value - dataRanges.minY) / yRange) * chartHeight;
+      ctx.beginPath();
+      ctx.moveTo(padding.left, padding.top);
+      ctx.lineTo(padding.left, padding.top + chartHeight);
+      ctx.stroke();
+
+      ctx.fillStyle = '#666';
+      ctx.font = '12px Arial';
+      ctx.textAlign = 'center';
+
+      if (xAxis?.title) {
+        ctx.fillText(xAxis.title, padding.left + chartWidth / 2, chartDimensions.totalHeight - 10);
+      }
+
+      if (yAxis?.title) {
+        ctx.save();
+        ctx.translate(15, padding.top + chartHeight / 2);
+        ctx.rotate(-Math.PI / 2);
+        ctx.fillText(yAxis.title, 0, 0);
+        ctx.restore();
+      }
+
+      ctx.textAlign = 'right';
+      for (let i = 0; i <= 5; i++) {
+        const value = dataRanges.minY + ((dataRanges.maxY - dataRanges.minY) / 5) * (5 - i);
+        const y = padding.top + (chartHeight / 5) * i;
+        ctx.fillText(value.toFixed(1), padding.left - 10, y + 5);
+      }
+
+      ctx.restore();
+    },
+    [chartDimensions, dataRanges, type, xAxis?.title, yAxis?.title]
+  );
+
+  const drawLineOrAreaChart = useCallback(
+    (ctx: CanvasRenderingContext2D, variant: 'line' | 'area') => {
+      const { padding, chartWidth, chartHeight } = chartDimensions;
+      const yRange = Math.max(dataRanges.maxY - dataRanges.minY || 0, 1);
+
+      normalizedData.forEach((series, seriesIndex) => {
+        const color = series.color || colors[seriesIndex % colors.length] || '#0066cc';
+
+        ctx.strokeStyle = color;
+        ctx.fillStyle = color;
+        ctx.lineWidth = 3;
+        ctx.lineCap = 'round';
+        ctx.lineJoin = 'round';
+
+        if (series.data.length === 0) return;
 
         ctx.beginPath();
-        ctx.arc(x, y, 4, 0, 2 * Math.PI);
+
+        series.data.forEach((point, index) => {
+          const x = padding.left + (chartWidth / Math.max(series.data.length - 1, 1)) * index;
+          const y =
+            padding.top +
+            chartHeight -
+            ((point.value - dataRanges.minY) / yRange) * chartHeight;
+
+          if (index === 0) {
+            ctx.moveTo(x, y);
+          } else {
+            ctx.lineTo(x, y);
+          }
+        });
+
+        if (variant === 'area') {
+          const lastX =
+            padding.left +
+            (chartWidth / Math.max(series.data.length - 1, 1)) * (series.data.length - 1);
+          const firstX = padding.left;
+          const baseY = padding.top + chartHeight;
+
+          ctx.lineTo(lastX, baseY);
+          ctx.lineTo(firstX, baseY);
+          ctx.closePath();
+          ctx.globalAlpha = 0.15;
+          ctx.fill();
+          ctx.globalAlpha = 1;
+        }
+
+        ctx.stroke();
+
+        series.data.forEach((point, index) => {
+          const x = padding.left + (chartWidth / Math.max(series.data.length - 1, 1)) * index;
+          const y =
+            padding.top +
+            chartHeight -
+            ((point.value - dataRanges.minY) / yRange) * chartHeight;
+
+          ctx.beginPath();
+          ctx.arc(x, y, 4, 0, 2 * Math.PI);
+          ctx.fill();
+
+          if (showTooltip) {
+            tooltipTargetsRef.current.push({
+              kind: 'point',
+              x,
+              y,
+              radius: 6,
+              value: point.value,
+              label: point.label ?? `Point ${index + 1}`,
+              series: series.name,
+              color,
+            });
+          }
+        });
+      });
+    },
+    [chartDimensions, colors, dataRanges, normalizedData, showTooltip]
+  );
+
+  const drawBarChart = useCallback(
+    (ctx: CanvasRenderingContext2D) => {
+      const { padding, chartWidth, chartHeight } = chartDimensions;
+      const yRange = Math.max(dataRanges.maxY - dataRanges.minY || 0, 1);
+
+      if (!normalizedData.length) return;
+
+      const maxDataPoints = normalizedData[0]?.data.length || 0;
+      if (maxDataPoints === 0) return;
+
+      const groupWidth = chartWidth / maxDataPoints;
+      const barWidth = groupWidth * 0.8;
+      const barSpacing = groupWidth * 0.2;
+
+      normalizedData.forEach((series, seriesIndex) => {
+        const color = series.color || colors[seriesIndex % colors.length] || '#0066cc';
+        ctx.fillStyle = color;
+
+        series.data.forEach((point, index) => {
+          const x =
+            padding.left +
+            groupWidth * index +
+            barSpacing / 2 +
+            (barWidth / normalizedData.length) * seriesIndex;
+          const individualWidth = barWidth / Math.max(normalizedData.length, 1);
+          const barHeight = ((point.value - dataRanges.minY) / yRange) * chartHeight;
+          const y = padding.top + chartHeight - barHeight;
+
+          ctx.fillRect(x, y, individualWidth, barHeight);
+
+          if (showTooltip) {
+            tooltipTargetsRef.current.push({
+              kind: 'bar',
+              x,
+              y,
+              width: individualWidth,
+              height: barHeight,
+              value: point.value,
+              label: point.label ?? `Category ${index + 1}`,
+              series: series.name,
+              color,
+            });
+          }
+        });
+      });
+    },
+    [chartDimensions, colors, dataRanges, normalizedData, showTooltip]
+  );
+
+  const drawPieChart = useCallback(
+    (ctx: CanvasRenderingContext2D) => {
+      const { chartWidth, chartHeight } = chartDimensions;
+      const centerX = width / 2;
+      const centerY = height / 2;
+      const radius = Math.min(chartWidth, chartHeight) / 3;
+
+      if (!normalizedData.length) return;
+
+      const series = normalizedData[0];
+      const dataPoints = series?.data ?? [];
+      const total = dataPoints.reduce((sum, point) => sum + point.value, 0);
+
+      if (total === 0) return;
+
+      let currentAngle = -Math.PI / 2;
+
+      dataPoints.forEach((point, index) => {
+        const sliceAngle = (point.value / total) * 2 * Math.PI;
+        const color = point.color || colors[index % colors.length] || '#0066cc';
+        const nextAngle = currentAngle + sliceAngle;
+        const percentage = total ? (point.value / total) * 100 : 0;
+
+        ctx.fillStyle = color;
+        ctx.beginPath();
+        ctx.moveTo(centerX, centerY);
+        ctx.arc(centerX, centerY, radius, currentAngle, nextAngle);
+        ctx.closePath();
         ctx.fill();
 
-        if (showTooltip) {
-          tooltipTargetsRef.current.push({
-            kind: 'point',
-            x,
-            y,
-            radius: 6,
-            value: point.value,
-            label: point.label ?? `Point ${index + 1}`,
-            series: series.name,
-            color,
-          });
+        if (point.value / total > 0.05) {
+          const labelAngle = currentAngle + sliceAngle / 2;
+          const labelX = centerX + Math.cos(labelAngle) * (radius * 0.7);
+          const labelY = centerY + Math.sin(labelAngle) * (radius * 0.7);
+
+          ctx.fillStyle = '#fff';
+          ctx.font = '12px Arial';
+          ctx.textAlign = 'center';
+          ctx.fillText(`${percentage.toFixed(1)}%`, labelX, labelY);
         }
-      });
-    });
-  };
-
-  const drawBarChart = (ctx: CanvasRenderingContext2D) => {
-    const { padding, chartWidth, chartHeight } = chartDimensions;
-    const yRange = Math.max(dataRanges.maxY - dataRanges.minY || 0, 1);
-
-    if (!normalizedData.length) return;
-
-    const maxDataPoints = normalizedData[0]?.data.length || 0;
-    if (maxDataPoints === 0) return;
-
-    const groupWidth = chartWidth / maxDataPoints;
-    const barWidth = groupWidth * 0.8;
-    const barSpacing = groupWidth * 0.2;
-
-    normalizedData.forEach((series, seriesIndex) => {
-      const color = series.color || colors[seriesIndex % colors.length] || '#0066cc';
-      ctx.fillStyle = color || '#000';
-
-      series.data.forEach((point, index) => {
-        const x =
-          padding.left +
-          groupWidth * index +
-          barSpacing / 2 +
-          (barWidth / normalizedData.length) * seriesIndex;
-        const individualWidth = barWidth / Math.max(normalizedData.length, 1);
-        const barHeight = ((point.value - dataRanges.minY) / yRange) * chartHeight;
-        const y = padding.top + chartHeight - barHeight;
-
-        ctx.fillRect(x, y, individualWidth, barHeight);
 
         if (showTooltip) {
           tooltipTargetsRef.current.push({
-            kind: 'bar',
-            x,
-            y,
-            width: individualWidth,
-            height: barHeight,
+            kind: 'slice',
+            startAngle: currentAngle,
+            endAngle: nextAngle,
+            centerX,
+            centerY,
+            radius,
             value: point.value,
-            label: point.label ?? `Category ${index + 1}`,
-            series: series.name,
+            label: point.label ?? series?.name ?? `Slice ${index + 1}`,
+            series: series?.name ?? 'Series 1',
             color,
+            percentage,
           });
         }
+
+        currentAngle = nextAngle;
       });
-    });
-  };
+    },
+    [chartDimensions, colors, height, normalizedData, showTooltip, width]
+  );
 
-  const drawPieChart = (ctx: CanvasRenderingContext2D) => {
-    const { chartWidth, chartHeight } = chartDimensions;
-    const centerX = width / 2;
-    const centerY = height / 2;
-    const radius = Math.min(chartWidth, chartHeight) / 3;
-
-    if (!normalizedData.length) return;
-
-    const data = normalizedData[0]?.data || [];
-    const total = data.reduce((sum, point) => sum + point.value, 0);
-
-    if (total === 0) return;
-
-    let currentAngle = -Math.PI / 2;
-
-    data.forEach((point, index) => {
-      const sliceAngle = (point.value / total) * 2 * Math.PI;
-      const color = point.color || colors[index % colors.length] || '#0066cc';
-      const nextAngle = currentAngle + sliceAngle;
-      const percentage = total ? (point.value / total) * 100 : 0;
-
-      ctx.fillStyle = color;
-      ctx.beginPath();
-      ctx.moveTo(centerX, centerY);
-      ctx.arc(centerX, centerY, radius, currentAngle, nextAngle);
-      ctx.closePath();
-      ctx.fill();
-
-      if (point.value / total > 0.05) {
-        const labelAngle = currentAngle + sliceAngle / 2;
-        const labelX = centerX + Math.cos(labelAngle) * (radius * 0.7);
-        const labelY = centerY + Math.sin(labelAngle) * (radius * 0.7);
-
-        ctx.fillStyle = '#fff';
-        ctx.font = '12px Arial';
-        ctx.textAlign = 'center';
-        ctx.fillText(`${((point.value / total) * 100).toFixed(1)}%`, labelX, labelY);
-      }
-
-      if (showTooltip) {
-        const sliceTooltipTarget: TooltipTarget = {
-          kind: 'slice',
-          startAngle: currentAngle,
-          endAngle: nextAngle,
-          centerX,
-          centerY,
-          radius,
-          value: point.value,
-          series: normalizedData[0]?.name || 'Series 1',
-          color,
-          percentage,
-        };
-        if (point.label !== undefined) {
-          sliceTooltipTarget.label = point.label;
-        }
-        tooltipTargetsRef.current.push(sliceTooltipTarget);
-      }
-
-      currentAngle = nextAngle;
-    });
-  };
-
-  // Draw chart
   useEffect(() => {
-    tooltipTargetsRef.current = [];
-    hideTooltip();
-
     const canvas = canvasRef.current;
     if (!canvas) {
       return;
     }
 
-    const ctx = canvas.getContext('2d');
-    if (!ctx) {
+    const context = canvas.getContext('2d');
+    if (!context) {
       return;
     }
 
-    canvas.width = width;
-    canvas.height = height;
+    canvas.width = chartDimensions.totalWidth;
+    canvas.height = chartDimensions.totalHeight;
 
-    ctx.clearRect(0, 0, width, height);
+    tooltipTargetsRef.current = [];
+    hideTooltip();
 
-    if (type !== 'pie') {
-      drawGrid(ctx);
-      drawAxes(ctx);
+    context.clearRect(0, 0, chartDimensions.totalWidth, chartDimensions.totalHeight);
+
+    if (!normalizedData.length) {
+      return;
     }
+
+    drawGrid(context);
+    drawAxes(context);
 
     switch (type) {
       case 'line':
+        drawLineOrAreaChart(context, 'line');
+        break;
       case 'area':
-        drawLineChart(ctx);
+        drawLineOrAreaChart(context, 'area');
         break;
       case 'bar':
-        drawBarChart(ctx);
+        drawBarChart(context);
         break;
       case 'pie':
-        drawPieChart(ctx);
+        drawPieChart(context);
         break;
       default:
-        drawLineChart(ctx);
+        drawLineOrAreaChart(context, 'line');
     }
   }, [
-    type,
-    normalizedData,
     chartDimensions,
-    dataRanges,
-    colors,
-    showGrid,
+    drawAxes,
+    drawBarChart,
+    drawGrid,
+    drawLineOrAreaChart,
+    drawPieChart,
     hideTooltip,
-    width,
-    height,
-    showTooltip,
+    normalizedData,
+    type,
   ]);
 
-  const chartClasses = classNames(
-    styles['dyn-chart'],
-    styles[`dyn-chart--${type}`],
-    className
-  );
+  const canvasAriaLabel = title ?? 'Chart visualization';
+  const describedBy = [subtitle ? subtitleId : undefined, ariaDescription ? descriptionId : undefined]
+    .filter(Boolean)
+    .join(' ');
 
   return (
-    <div className={chartClasses} ref={containerRef}>
-      {(title || subtitle) && (
-        <div className={styles['dyn-chart__header']}>
-          {title && <h3 className={styles['dyn-chart__title']}>{title}</h3>}
-          {subtitle && (
-            <p className={styles['dyn-chart__subtitle']}>{subtitle}</p>
+    <div
+      {...rest}
+      ref={ref}
+      id={id}
+      data-testid={dataTestId}
+      className={cn(styles.root, typeClassNameMap[type], className)}
+    >
+      <figure className={styles.figure} aria-labelledby={titleId} aria-describedby={describedBy || undefined}>
+        {(title || subtitle) && (
+          <header className={styles.header}>
+            {title && (
+              <h3 id={titleId} className={styles.title}>
+                {title}
+              </h3>
+            )}
+            {subtitle && (
+              <p id={subtitleId} className={styles.subtitle}>
+                {subtitle}
+              </p>
+            )}
+          </header>
+        )}
+
+        <div className={styles.content}>
+          <canvas
+            ref={canvasRef}
+            className={styles.canvas}
+            role="img"
+            aria-label={canvasAriaLabel}
+            aria-describedby={describedBy || undefined}
+            width={chartDimensions.totalWidth}
+            height={chartDimensions.totalHeight}
+            style={{ width, height }}
+            onMouseMove={showTooltip ? handleMouseMove : undefined}
+            onMouseLeave={showTooltip ? handleMouseLeave : undefined}
+          />
+
+          {showTooltip && (
+            <div
+              className={styles.tooltip}
+              data-visible={tooltipState.visible}
+              aria-hidden={!tooltipState.visible}
+              style={{
+                left: `${tooltipState.x}px`,
+                top: `${tooltipState.y}px`,
+              }}
+            >
+              {(tooltipState.series || tooltipState.color || typeof tooltipState.percentage === 'number') && (
+                <div className={styles.tooltipHeader}>
+                  {tooltipState.color && (
+                    <span
+                      className={styles.tooltipColor}
+                      style={{ backgroundColor: tooltipState.color }}
+                    />
+                  )}
+                  {tooltipState.series && (
+                    <span className={styles.tooltipSeries}>{tooltipState.series}</span>
+                  )}
+                  {typeof tooltipState.percentage === 'number' && (
+                    <span className={styles.tooltipPercentage}>
+                      {tooltipState.percentage.toFixed(1)}%
+                    </span>
+                  )}
+                </div>
+              )}
+              <div className={styles.tooltipValue}>{tooltipState.value}</div>
+              {tooltipState.label && <div className={styles.tooltipLabel}>{tooltipState.label}</div>}
+            </div>
+          )}
+
+          {emptyStateMessage && (
+            <p className={styles.emptyState} role="status">
+              {emptyStateMessage}
+            </p>
           )}
         </div>
-      )}
 
-      <div className={styles['dyn-chart__content']}>
-        <canvas
-          ref={canvasRef}
-          className={styles['dyn-chart__canvas']}
-          role="presentation"
-          aria-hidden={true}
-          style={{ width, height }}
-          onMouseMove={showTooltip ? handleMouseMove : undefined}
-          onMouseLeave={showTooltip ? handleMouseLeave : undefined}
-        />
-        {showTooltip && (
-          <div
-            className={styles['dyn-chart__tooltip']}
-            data-visible={tooltipState.visible}
-            aria-hidden={!tooltipState.visible}
-            style={{
-              left: `${tooltipState.x}px`,
-              top: `${tooltipState.y}px`,
-            }}
-          >
-            {(tooltipState.series ||
-              tooltipState.color ||
-              typeof tooltipState.percentage === 'number') && (
-              <div className={styles['dyn-chart__tooltip-header']}>
-                {tooltipState.color && (
-                  <span
-                    className={styles['dyn-chart__tooltip-color']}
-                    style={{ backgroundColor: tooltipState.color }}
-                  />
-                )}
-                {tooltipState.series && (
-                  <span className={styles['dyn-chart__tooltip-series']}>
-                    {tooltipState.series}
-                  </span>
-                )}
-                {typeof tooltipState.percentage === 'number' && (
-                  <span className={styles['dyn-chart__tooltip-percentage']}>
-                    {tooltipState.percentage.toFixed(1)}%
-                  </span>
-                )}
+        {showLegend && legendItems.length > 0 && (
+          <div className={styles.legend} role="list">
+            {legendItems.map(item => (
+              <div key={item.id} className={styles.legendItem} role="listitem">
+                <span
+                  className={styles.legendColor}
+                  style={{ backgroundColor: normalizedData[item.seriesIndex]?.color }}
+                />
+                <span className={styles.legendLabel}>{item.label}</span>
               </div>
-            )}
-            <div className={styles['dyn-chart__tooltip-value']}>
-              {tooltipState.value}
-            </div>
-            {tooltipState.label && (
-              <div className={styles['dyn-chart__tooltip-label']}>
-                {tooltipState.label}
-              </div>
-            )}
+            ))}
           </div>
         )}
-      </div>
 
-      {showLegend && normalizedData.length > 0 && (
-        <div className={styles['dyn-chart__legend']}>
-          {normalizedData.map((series, index) => (
-            <div key={series.name} className={styles['dyn-chart__legend-item']}>
-              <div
-                className={styles['dyn-chart__legend-color']}
-                style={{
-                  backgroundColor:
-                    series.color || colors[index % colors.length],
-                }}
-              />
-              <span className={styles['dyn-chart__legend-label']}>
-                {series.name}
-              </span>
-            </div>
-          ))}
-        </div>
-      )}
+        {children}
+
+        {ariaDescription && (
+          <figcaption id={descriptionId} className={styles.visuallyHidden}>
+            {ariaDescription}
+          </figcaption>
+        )}
+      </figure>
     </div>
   );
-};
+});
 
 DynChart.displayName = 'DynChart';
 
+export { DynChart };
 export default DynChart;

--- a/packages/dyn-ui-react/src/components/DynChart/DynChart.types.ts
+++ b/packages/dyn-ui-react/src/components/DynChart/DynChart.types.ts
@@ -1,4 +1,4 @@
-import { BaseComponentProps } from '../../types';
+import type { BaseComponentProps } from '../../types';
 
 export interface ChartDataPoint {
   label?: string;
@@ -21,42 +21,73 @@ export interface ChartAxis {
 
 export type ChartType = 'line' | 'bar' | 'pie' | 'area';
 
-export interface DynChartProps extends BaseComponentProps {
+export type DynChartData = ChartDataPoint[] | ChartSeries[];
+
+export interface DynChartOptions {
+  showLegend?: boolean;
+  showTooltip?: boolean;
+  showGrid?: boolean;
+}
+
+export interface DynChartProps extends BaseComponentProps, DynChartOptions {
   /** Chart type */
   type?: ChartType;
-  
+
   /** Chart data - can be array of data points or series */
-  data: ChartDataPoint[] | ChartSeries[];
-  
+  data?: DynChartData;
+
   /** Chart title */
   title?: string;
-  
+
   /** Chart subtitle */
   subtitle?: string;
-  
+
   /** Chart width in pixels */
   width?: number;
-  
+
   /** Chart height in pixels */
   height?: number;
-  
+
   /** Color palette for chart elements */
   colors?: string[];
-  
-  /** Show legend */
-  showLegend?: boolean;
-  
-  /** Show tooltip on hover */
-  showTooltip?: boolean;
-  
-  /** Show grid lines */
-  showGrid?: boolean;
-  
+
   /** X axis configuration */
   xAxis?: ChartAxis;
-  
+
   /** Y axis configuration */
   yAxis?: ChartAxis;
+
+  /** Accessible description for assistive technologies */
+  ariaDescription?: string;
 }
+
+export interface NormalizedChartSeries extends ChartSeries {
+  color: string;
+}
+
+export interface DynChartLegendItem {
+  id: string;
+  label: string;
+  color: string;
+  seriesIndex: number;
+}
+
+export type DynChartDefaultProps = Required<
+  Pick<
+    DynChartProps,
+    'type' | 'data' | 'width' | 'height' | 'colors' | 'showLegend' | 'showTooltip' | 'showGrid'
+  >
+>;
+
+export const DYN_CHART_DEFAULT_PROPS: DynChartDefaultProps = {
+  type: 'line',
+  data: [],
+  width: 400,
+  height: 300,
+  colors: ['#0066cc', '#00b248', '#f44336', '#ff9800', '#9c27b0'],
+  showLegend: true,
+  showTooltip: true,
+  showGrid: true,
+};
 
 export type DynChartType = DynChartProps;

--- a/packages/dyn-ui-react/src/components/DynChart/DynChart.utils.ts
+++ b/packages/dyn-ui-react/src/components/DynChart/DynChart.utils.ts
@@ -1,0 +1,148 @@
+import type {
+  ChartAxis,
+  ChartDataPoint,
+  ChartSeries,
+  DynChartData,
+  DynChartLegendItem,
+  NormalizedChartSeries,
+} from './DynChart.types';
+
+export interface ChartDimensions {
+  padding: { top: number; right: number; bottom: number; left: number };
+  chartWidth: number;
+  chartHeight: number;
+  totalWidth: number;
+  totalHeight: number;
+}
+
+export interface DataRanges {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+}
+
+const DEFAULT_PADDING = { top: 20, right: 20, bottom: 60, left: 60 } as const;
+
+const FALLBACK_COLORS = ['#0066cc', '#00b248', '#f44336', '#ff9800', '#9c27b0'];
+
+export const EMPTY_DATA_RANGES: DataRanges = {
+  minX: 0,
+  maxX: 0,
+  minY: 0,
+  maxY: 1,
+};
+
+export function isSeriesCollection(data?: DynChartData): data is ChartSeries[] {
+  return Array.isArray(data) && data.length > 0 && typeof data[0] === 'object' && 'name' in (data[0] as ChartSeries);
+}
+
+export function normalizeSeries(
+  data: DynChartData | undefined,
+  palette: string[] = FALLBACK_COLORS
+): NormalizedChartSeries[] {
+  if (!data || data.length === 0) {
+    return [];
+  }
+
+  if (isSeriesCollection(data)) {
+    return data.map((series, index) => ({
+      ...series,
+      color: series.color ?? palette[index % palette.length] ?? FALLBACK_COLORS[index % FALLBACK_COLORS.length],
+    }));
+  }
+
+  const fallbackColor = palette[0] ?? FALLBACK_COLORS[0];
+
+  return [
+    {
+      name: 'Series 1',
+      data: data as ChartDataPoint[],
+      color: fallbackColor,
+    },
+  ];
+}
+
+export function calculateChartDimensions(width: number, height: number): ChartDimensions {
+  const chartWidth = Math.max(0, width - (DEFAULT_PADDING.left + DEFAULT_PADDING.right));
+  const chartHeight = Math.max(0, height - (DEFAULT_PADDING.top + DEFAULT_PADDING.bottom));
+
+  return {
+    padding: { ...DEFAULT_PADDING },
+    chartWidth,
+    chartHeight,
+    totalWidth: width,
+    totalHeight: height,
+  };
+}
+
+export function calculateDataRanges(
+  seriesCollection: NormalizedChartSeries[],
+  axis?: ChartAxis
+): DataRanges {
+  if (seriesCollection.length === 0) {
+    if (axis?.min !== undefined && axis?.max !== undefined) {
+      return { minX: 0, maxX: 0, minY: axis.min, maxY: axis.max };
+    }
+
+    return EMPTY_DATA_RANGES;
+  }
+
+  let minY = axis?.min ?? Number.POSITIVE_INFINITY;
+  let maxY = axis?.max ?? Number.NEGATIVE_INFINITY;
+  let maxX = 0;
+
+  seriesCollection.forEach(series => {
+    series.data.forEach((point, index) => {
+      maxX = Math.max(maxX, index);
+
+      if (axis?.min === undefined) {
+        minY = Math.min(minY, point.value);
+      }
+
+      if (axis?.max === undefined) {
+        maxY = Math.max(maxY, point.value);
+      }
+    });
+  });
+
+  if (!Number.isFinite(minY) || !Number.isFinite(maxY)) {
+    return { ...EMPTY_DATA_RANGES, maxX };
+  }
+
+  if (axis?.min === undefined) {
+    minY = Math.min(minY, 0);
+  }
+
+  if (axis?.max === undefined) {
+    maxY = maxY === minY ? minY + 1 : maxY;
+  }
+
+  return {
+    minX: 0,
+    maxX,
+    minY,
+    maxY,
+  };
+}
+
+export function buildLegendItems(seriesCollection: NormalizedChartSeries[]): DynChartLegendItem[] {
+  return seriesCollection.map((series, index) => ({
+    id: `${series.name}-${index}`,
+    label: series.name,
+    color: series.color,
+    seriesIndex: index,
+  }));
+}
+
+export function getEmptyStateMessage(seriesCollection: NormalizedChartSeries[]): string {
+  if (seriesCollection.length === 0) {
+    return 'No chart data available';
+  }
+
+  const totalValues = seriesCollection.reduce((total, series) => {
+    return total + series.data.reduce((sum, point) => sum + Math.abs(point.value), 0);
+  }, 0);
+
+  return totalValues === 0 ? 'Chart data contains no measurable values' : '';
+}

--- a/packages/dyn-ui-react/src/components/DynChart/index.ts
+++ b/packages/dyn-ui-react/src/components/DynChart/index.ts
@@ -1,9 +1,14 @@
-// Standardized exports for DynChart component
 export { DynChart } from './DynChart';
 export { default } from './DynChart';
+export { DYN_CHART_DEFAULT_PROPS } from './DynChart.types';
 export type {
   DynChartProps,
   DynChartData,
   ChartType,
-  ChartOptions
+  ChartAxis,
+  ChartDataPoint,
+  ChartSeries,
+  DynChartOptions,
+  DynChartLegendItem,
+  DynChartDefaultProps,
 } from './DynChart.types';

--- a/packages/dyn-ui-react/src/components/index.ts
+++ b/packages/dyn-ui-react/src/components/index.ts
@@ -108,10 +108,13 @@ export type {
 // Data Display Component Types
 export type {
   DynChartProps,
+  DynChartData,
   ChartType,
   ChartDataPoint,
   ChartSeries,
-  ChartAxis
+  ChartAxis,
+  DynChartOptions,
+  DynChartLegendItem
 } from './DynChart/DynChart.types';
 export type {
   DynGaugeProps,


### PR DESCRIPTION
## Summary
- rework DynChart types to expose default props, variant options, and legend metadata shared across consumers
- refactor DynChart implementation with forwardRef, modular utilities, improved accessibility, and updated CSS module classes
- refresh unit tests, Storybook stories, and export barrels to reflect the standardized API
- ensure tooltip state and pie slice targets always provide string labels to satisfy strict optional property typing
- configure design-tokens and react-demo Vitest scripts to pass when no files match filtered runs

## Testing
- pnpm test -- DynChart

------
https://chatgpt.com/codex/tasks/task_e_68e4484f9b2c83248663bd88af4f11d4